### PR TITLE
feat: add testing and provide new override method functionality - eng-6332

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    secrets-manager (1.2.0)
+    secrets-manager (1.1.0)
       aws-sdk-secretsmanager (>= 1.31.0)
       concurrent-ruby (>= 1.0)
 
@@ -23,6 +23,10 @@ GEM
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
+    faker (2.19.0)
+      i18n (>= 1.6, < 2)
+    i18n (1.8.10)
+      concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     method_source (1.0.0)
     pry (0.13.1)
@@ -49,6 +53,7 @@ PLATFORMS
 
 DEPENDENCIES
   bundler (~> 2.0)
+  faker
   pry (~> 0.13.1)
   rake (~> 10.0)
   rspec (~> 3.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    secrets-manager (1.2.0)
+    secrets-manager (1.1.0)
       activesupport (~> 5.0, >= 5.0.0.1)
       aws-sdk-secretsmanager (>= 1.31.0)
       concurrent-ruby (>= 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    secrets-manager (1.1.0)
+    secrets-manager (1.2.0)
       aws-sdk-secretsmanager (>= 1.31.0)
       concurrent-ruby (>= 1.0)
 
@@ -20,9 +20,14 @@ GEM
       aws-sigv4 (~> 1.1)
     aws-sigv4 (1.1.0)
       aws-eventstream (~> 1.0, >= 1.0.2)
+    coderay (1.1.3)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
     jmespath (1.4.0)
+    method_source (1.0.0)
+    pry (0.13.1)
+      coderay (~> 1.1)
+      method_source (~> 1.0)
     rake (10.5.0)
     rspec (3.8.0)
       rspec-core (~> 3.8.0)
@@ -37,15 +42,18 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    timecop (0.8.1)
 
 PLATFORMS
   ruby
 
 DEPENDENCIES
   bundler (~> 2.0)
+  pry (~> 0.13.1)
   rake (~> 10.0)
   rspec (~> 3.0)
   secrets-manager!
+  timecop (~> 0.8.1)
 
 BUNDLED WITH
    2.1.4

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    secrets-manager (1.1.0)
+    secrets-manager (1.2.0)
       activesupport (~> 5.0, >= 5.0.0.1)
       aws-sdk-secretsmanager (>= 1.31.0)
       concurrent-ruby (>= 1.0)

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -2,24 +2,30 @@ PATH
   remote: .
   specs:
     secrets-manager (1.1.0)
+      activesupport (~> 5.0, >= 5.0.0.1)
       aws-sdk-secretsmanager (>= 1.31.0)
       concurrent-ruby (>= 1.0)
 
 GEM
   remote: https://rubygems.org/
   specs:
-    aws-eventstream (1.0.3)
-    aws-partitions (1.276.0)
-    aws-sdk-core (3.90.1)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    activesupport (5.2.6)
+      concurrent-ruby (~> 1.0, >= 1.0.2)
+      i18n (>= 0.7, < 2)
+      minitest (~> 5.1)
+      tzinfo (~> 1.1)
+    aws-eventstream (1.1.1)
+    aws-partitions (1.492.0)
+    aws-sdk-core (3.119.1)
+      aws-eventstream (~> 1, >= 1.0.2)
       aws-partitions (~> 1, >= 1.239.0)
       aws-sigv4 (~> 1.1)
       jmespath (~> 1.0)
-    aws-sdk-secretsmanager (1.33.0)
-      aws-sdk-core (~> 3, >= 3.71.0)
+    aws-sdk-secretsmanager (1.48.0)
+      aws-sdk-core (~> 3, >= 3.119.0)
       aws-sigv4 (~> 1.1)
-    aws-sigv4 (1.1.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
+    aws-sigv4 (1.2.4)
+      aws-eventstream (~> 1, >= 1.0.2)
     coderay (1.1.3)
     concurrent-ruby (1.1.6)
     diff-lcs (1.3)
@@ -29,6 +35,7 @@ GEM
       concurrent-ruby (~> 1.0)
     jmespath (1.4.0)
     method_source (1.0.0)
+    minitest (5.14.4)
     pry (0.13.1)
       coderay (~> 1.1)
       method_source (~> 1.0)
@@ -46,7 +53,10 @@ GEM
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.8.0)
     rspec-support (3.8.2)
+    thread_safe (0.3.6)
     timecop (0.8.1)
+    tzinfo (1.2.9)
+      thread_safe (~> 0.1)
 
 PLATFORMS
   ruby

--- a/lib/secrets-manager.rb
+++ b/lib/secrets-manager.rb
@@ -4,7 +4,7 @@ require "version"
 require "aws-sdk-secretsmanager"
 require "concurrent-ruby"
 require "json"
-require 'active_support/core_ext/object/blank.rb'
+require "active_support/core_ext/object/blank.rb"
 require "base64"
 
 module SecretsManager
@@ -47,15 +47,15 @@ module SecretsManager
     end
 
     def secret_env
-      ENV['AWS_SECRETS_ENV'] || ENV['RACK_ENV'] || 'development'
+      ENV["AWS_SECRETS_ENV"] || ENV["RACK_ENV"] || "development"
     end
 
     def client
       return @aws_client if @aws_client
 
       @_client ||= Aws::SecretsManager::Client.new({
-        region: ENV.fetch('AWS_SECRETS_REGION', 'us-east-1'),
-        credentials: Aws::Credentials.new(ENV['AWS_SECRETS_KEY'], ENV['AWS_SECRETS_SECRET'])
+        region: ENV.fetch("AWS_SECRETS_REGION", "us-east-1"),
+        credentials: Aws::Credentials.new(ENV["AWS_SECRETS_KEY"], ENV["AWS_SECRETS_SECRET"])
       })
     end
 
@@ -63,7 +63,7 @@ module SecretsManager
       if secret_path.start_with?("global")
         resolved_path = secret_path
       else
-        resolved_path = secret_env + '/' + secret_path
+        resolved_path = secret_env + "/" + secret_path
       end
 
       cached_value = cache.find(resolved_path)

--- a/lib/secrets-manager.rb
+++ b/lib/secrets-manager.rb
@@ -22,7 +22,9 @@ module SecretsManager
     end
 
     def set(path, value, ttl = 86400)
+
       @_cache[path] = {expires_at: (Time.now + ttl), value: value}
+
       return self
     end
 
@@ -67,10 +69,11 @@ module SecretsManager
 
       response = client.get_secret_value(secret_id: resolved_path)
       return nil unless response && response.secret_string
-      object = JSON.parse(response.secret_string, symbolize_names: true)
 
+      object = JSON.parse(response.secret_string, symbolize_names: true)
       value = parse_value(object)
       cache.set(resolved_path, value, parse_ttl(object))
+
       return value
     rescue Aws::SecretsManager::Errors::ResourceNotFoundException => e
       raise SecretsManager::SecretNotFound, "Could not find secret with path #{resolved_path}"
@@ -81,6 +84,7 @@ module SecretsManager
     end
 
     private
+
     def parse_ttl(data)
       ## Default to one day cache TTL
       return 86400 unless data[:ttl].present?
@@ -106,6 +110,5 @@ module SecretsManager
 
       return value
     end
-
   end
 end

--- a/lib/secrets-manager.rb
+++ b/lib/secrets-manager.rb
@@ -4,6 +4,8 @@ require "version"
 require "aws-sdk-secretsmanager"
 require "concurrent-ruby"
 require "json"
+require 'active_support/core_ext/object/blank.rb'
+require "base64"
 
 module SecretsManager
   class SecretNotFound < StandardError; end;
@@ -22,7 +24,6 @@ module SecretsManager
     end
 
     def set(path, value, ttl = 86400)
-
       @_cache[path] = {expires_at: (Time.now + ttl), value: value}
 
       return self
@@ -32,6 +33,7 @@ module SecretsManager
       fetched = @_cache[path]
       return unless fetched
       return unless !fetched[:expires_at].nil? && (fetched[:expires_at]) > Time.now
+
       fetched[:value]
     end
   end
@@ -72,6 +74,7 @@ module SecretsManager
 
       object = JSON.parse(response.secret_string, symbolize_names: true)
       value = parse_value(object)
+
       cache.set(resolved_path, value, parse_ttl(object))
 
       return value

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module SecretsManager
-  VERSION = "1.1.0"
+  VERSION = "1.2.0"
 end

--- a/lib/version.rb
+++ b/lib/version.rb
@@ -1,3 +1,3 @@
 module SecretsManager
-  VERSION = "1.2.0"
+  VERSION = "1.1.0"
 end

--- a/secrets-manager.gemspec
+++ b/secrets-manager.gemspec
@@ -27,6 +27,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "concurrent-ruby", ">= 1.0"
   spec.add_dependency 'aws-sdk-secretsmanager', '>= 1.31.0'
+  spec.add_dependency 'activesupport', '~> 5.0', '>= 5.0.0.1'
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/secrets-manager.gemspec
+++ b/secrets-manager.gemspec
@@ -33,4 +33,5 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "rspec", "~> 3.0"
   spec.add_development_dependency "pry", "~> 0.13.1"
   spec.add_development_dependency "timecop", "~> 0.8.1"
+  spec.add_development_dependency "faker"
 end

--- a/secrets-manager.gemspec
+++ b/secrets-manager.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |spec|
 
   # Specify which files should be added to the gem when it is released.
   # The `git ls-files -z` loads the files in the RubyGem that have been added into git.
-  spec.files         = Dir.chdir(File.expand_path('..', __FILE__)) do
+  spec.files         = Dir.chdir(File.expand_path("..", __FILE__)) do
     `git ls-files -z`.split("\x0").reject { |f| f.match(%r{^(test|spec|features)/}) }
   end
   spec.bindir        = "exe"
@@ -26,8 +26,8 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
 
   spec.add_dependency "concurrent-ruby", ">= 1.0"
-  spec.add_dependency 'aws-sdk-secretsmanager', '>= 1.31.0'
-  spec.add_dependency 'activesupport', '~> 5.0', '>= 5.0.0.1'
+  spec.add_dependency "aws-sdk-secretsmanager", ">= 1.31.0"
+  spec.add_dependency "activesupport", "~> 5.0", ">= 5.0.0.1"
 
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"

--- a/secrets-manager.gemspec
+++ b/secrets-manager.gemspec
@@ -31,4 +31,6 @@ Gem::Specification.new do |spec|
   spec.add_development_dependency "bundler", "~> 2.0"
   spec.add_development_dependency "rake", "~> 10.0"
   spec.add_development_dependency "rspec", "~> 3.0"
+  spec.add_development_dependency "pry", "~> 0.13.1"
+  spec.add_development_dependency "timecop", "~> 0.8.1"
 end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -1,9 +1,81 @@
-RSpec.describe Secrets::Manager do
-  it "has a version number" do
-    expect(Secrets::Manager::VERSION).not_to be nil
+# frozen_string_literal: true
+
+RSpec.describe SecretsManager do
+  it "returns the correct version" do
+    expect(described_class::VERSION).to eq("1.2.0")
   end
 
-  it "does something useful" do
-    expect(false).to eq(true)
+  describe "#new" do
+    let(:args) { { client: double() } }
+
+    after { described_class.new(args) }
+
+    it "initializes the nested Manager Class" do
+      expect(described_class::Manager).to receive(:new).with(args)
+    end
+  end
+
+  context "SecretsManager::Cache" do
+    describe "#new" do
+      after { described_class::Cache.new }
+
+      it "initializes the Concurrent::Map Class" do
+        expect(Concurrent::Map).to receive(:new)
+      end
+    end
+
+    describe "#reset" do
+      after { described_class::Cache.new.reset }
+
+      it "initializes the Concurrent::Map Class" do
+        expect(Concurrent::Map).to receive(:new).twice
+      end
+    end
+
+    describe "#set" do
+      let(:path) { "TEST/PATH" }
+      let(:value) { "TESTVALUE" }
+      let(:ttl) { 86400 }
+
+      subject(:secrets_manager) do
+        klass = described_class::Cache.new.set(path, value)
+        klass.instance_variable_get(:@_cache).values.first
+      end
+
+      it "initializes the Concurrent::Map Class" do
+        expect(Concurrent::Map).to receive(:new).and_call_original
+        secrets_manager
+      end
+
+      it "returns the cached parameter value" do
+        expect(secrets_manager[:value]).to eq(value)
+      end
+
+      it "returns the cached parameter ttl" do
+        expect(secrets_manager[:expires_at]).to eq(Time.now + ttl)
+      end
+    end
+
+    describe "#find", focus: true do
+      pending
+    end
+  end
+
+  context "SecretsManager::Manager" do
+    describe "#secret_env" do
+      pending
+    end
+
+    describe "#client" do
+      pending
+    end
+
+    describe "#fetch" do
+      pending
+    end
+
+    describe "#[]" do
+      pending
+    end
   end
 end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SecretsManager do
   it "returns the correct version" do
-    expect(described_class::VERSION).to eq("1.2.0")
+    expect(described_class::VERSION).to eq("1.1.0")
   end
 
   describe "#new" do
@@ -33,8 +33,8 @@ RSpec.describe SecretsManager do
     end
 
     describe "#set" do
-      let(:path) { "TEST/PATH" }
-      let(:value) { "TESTVALUE" }
+      let(:path) { "#{Faker::Lorem.word}/#{Faker::Lorem.word}" }
+      let(:value) { Faker::Lorem.word }
       let(:ttl) { 86400 }
 
       subject(:secrets_manager) do
@@ -43,7 +43,7 @@ RSpec.describe SecretsManager do
       end
 
       it "initializes the Concurrent::Map Class" do
-        expect(Concurrent::Map).to receive(:new).and_call_original
+        expect(Concurrent::Map).to receive(:new).twice.and_call_original
         secrets_manager
       end
 
@@ -56,25 +56,217 @@ RSpec.describe SecretsManager do
       end
     end
 
-    describe "#find", focus: true do
+    describe "#find" do
       pending
     end
   end
 
   context "SecretsManager::Manager" do
     describe "#secret_env" do
-      pending
+      let(:value) { Faker::Lorem.word }
+
+      context "when ENV AWS_SECRETS_ENV" do
+        subject(:secret_env) { described_class::Manager.new.secret_env }
+
+        before do
+          ENV['AWS_SECRETS_ENV_TMP'] = ENV['AWS_SECRETS_ENV'] unless ENV.fetch('AWS_SECRETS_ENV', nil) == nil
+          ENV['AWS_SECRETS_ENV'] = value
+        end
+
+        after do
+          if ENV.fetch('AWS_SECRETS_ENV_TMP', nil) == nil
+            ENV['AWS_SECRETS_ENV'] = ENV['AWS_SECRETS_ENV_TMP']
+          else
+            ENV.delete("AWS_SECRETS_ENV")
+          end
+
+          ENV.delete("AWS_SECRETS_ENV_TMP")
+        end
+
+        it "returns AWS_SECRETS_ENV" do
+          expect(secret_env).to eq(value)
+        end
+      end
+
+      context "when ENV RACK_ENV" do
+        subject(:secret_env) { described_class::Manager.new.secret_env }
+
+        before do
+          ENV['AWS_SECRETS_ENV_TMP'] = ENV['AWS_SECRETS_ENV'] unless ENV.fetch('AWS_SECRETS_ENV', nil) == nil
+          ENV['RACK_ENV_TMP'] = ENV['RACK_ENV'] unless ENV.fetch('RACK_ENV', nil) == nil
+          ENV['RACK_ENV'] = value
+        end
+
+        after do
+          if ENV.fetch('AWS_SECRETS_ENV_TMP', nil) == nil
+            ENV['AWS_SECRETS_ENV'] = ENV['AWS_SECRETS_ENV_TMP']
+          else
+            ENV.delete("AWS_SECRETS_ENV")
+          end
+
+          if ENV.fetch('RACK_ENV_TMP', nil) == nil
+            ENV['RACK_ENV'] = ENV['RACK_ENV_TMP']
+          else
+            ENV.delete("RACK_ENV")
+          end
+
+          ENV.delete("AWS_SECRETS_ENV_TMP")
+          ENV.delete("RACK_ENV_TMP")
+        end
+
+        it "returns RACK_ENV" do
+          expect(secret_env).to eq(value)
+        end
+      end
+
+      context "when default" do
+        subject(:secret_env) { described_class::Manager.new.secret_env }
+
+        before do
+          ENV['AWS_SECRETS_ENV_TMP'] = ENV['AWS_SECRETS_ENV'] unless ENV.fetch('AWS_SECRETS_ENV', nil) == nil
+          ENV['RACK_ENV_TMP'] = ENV['RACK_ENV'] unless ENV.fetch('RACK_ENV', nil) == nil
+          ENV.delete("AWS_SECRETS_ENV")
+          ENV.delete("RACK_ENV")
+        end
+
+        after do
+          if ENV.fetch('AWS_SECRETS_ENV_TMP', nil) == nil
+            ENV['AWS_SECRETS_ENV'] = ENV['AWS_SECRETS_ENV_TMP']
+          end
+
+          if ENV.fetch('RACK_ENV_TMP', nil) == nil
+            ENV['RACK_ENV'] = ENV['RACK_ENV_TMP']
+          end
+
+          ENV.delete("AWS_SECRETS_ENV_TMP")
+          ENV.delete("RACK_ENV_TMP")
+        end
+
+        it "returns development" do
+          expect(secret_env).to eq("development")
+        end
+      end
     end
 
     describe "#client" do
+      context "without aws client supplied" do
+        let(:aws_secrets_key_value) { Faker::Lorem.word }
+        let(:aws_secrets_secret_value) { Faker::Lorem.word }
+        let(:aws_credentials_double) { double(Aws::Credentials) }
+
+        subject(:client) { described_class::Manager.new.client }
+
+        before do
+          ENV['AWS_SECRETS_KEY_TMP'] = ENV['AWS_SECRETS_KEY'] unless ENV.fetch('AWS_SECRETS_KEY', nil) == nil
+          ENV['AWS_SECRETS_SECRET_TMP'] = ENV['AWS_SECRETS_SECRET'] unless ENV.fetch('AWS_SECRETS_SECRET', nil) == nil
+          ENV['AWS_SECRETS_KEY'] = aws_secrets_key_value
+          ENV['AWS_SECRETS_SECRET'] = aws_secrets_secret_value
+
+          allow(Aws::Credentials).to receive(:new).with(aws_secrets_key_value, aws_secrets_secret_value).and_return(aws_credentials_double)
+        end
+
+        after do
+          if ENV.fetch('AWS_SECRETS_KEY_TMP', nil) == nil
+            ENV['AWS_SECRETS_KEY'] = ENV['AWS_SECRETS_KEY_TMP']
+          end
+
+          if ENV.fetch('AWS_SECRETS_SECRET_TMP', nil) == nil
+            ENV['AWS_SECRETS_SECRET'] = ENV['AWS_SECRETS_SECRET_TMP']
+          end
+
+          ENV.delete("AWS_SECRETS_KEY_TMP")
+          ENV.delete("AWS_SECRETS_SECRET_TMP")
+        end
+
+        context "without AWS_SECRETS_REGION" do
+          let(:configuration) do
+            {
+              region: "us-east-1",
+              credentials: aws_credentials_double
+            }
+          end
+
+          it "returns client" do
+            expect(Aws::SecretsManager::Client).to receive(:new).with(configuration)
+
+            client
+          end
+
+          it "sets credentials" do
+            expect(Aws::Credentials).to receive(:new).with(aws_secrets_key_value, aws_secrets_secret_value).and_return(aws_credentials_double)
+
+            client
+          end
+        end
+
+        context "with AWS_SECRETS_REGION" do
+          let(:aws_secrets_region_value) { Faker::Lorem.word }
+          let(:configuration) do
+            {
+              region: aws_secrets_region_value,
+              credentials: aws_credentials_double
+            }
+          end
+
+          before do
+            ENV['AWS_SECRETS_KEY_TMP'] = ENV['AWS_SECRETS_KEY'] unless ENV.fetch('AWS_SECRETS_KEY', nil) == nil
+            ENV['AWS_SECRETS_SECRET_TMP'] = ENV['AWS_SECRETS_SECRET'] unless ENV.fetch('AWS_SECRETS_SECRET', nil) == nil
+            ENV['AWS_SECRETS_REGION_TMP'] = ENV['AWS_SECRETS_REGION'] unless ENV.fetch('AWS_SECRETS_REGION', nil) == nil
+            ENV['AWS_SECRETS_KEY'] = aws_secrets_key_value
+            ENV['AWS_SECRETS_SECRET'] = aws_secrets_secret_value
+            ENV['AWS_SECRETS_REGION'] = aws_secrets_region_value
+
+            allow(Aws::Credentials).to receive(:new).with(aws_secrets_key_value, aws_secrets_secret_value).and_return(aws_credentials_double)
+          end
+
+          after do
+            if ENV.fetch('AWS_SECRETS_KEY_TMP', nil) == nil
+              ENV['AWS_SECRETS_KEY'] = ENV['AWS_SECRETS_KEY_TMP']
+            end
+
+            if ENV.fetch('AWS_SECRETS_SECRET_TMP', nil) == nil
+              ENV['AWS_SECRETS_SECRET'] = ENV['AWS_SECRETS_SECRET_TMP']
+            end
+
+            if ENV.fetch('AWS_SECRETS_REGION_TMP', nil) == nil
+              ENV['AWS_SECRETS_REGION'] = ENV['AWS_SECRETS_REGION_TMP']
+            end
+
+            ENV.delete("AWS_SECRETS_KEY_TMP")
+            ENV.delete("AWS_SECRETS_SECRET_TMP")
+            ENV.delete("AWS_SECRETS_REGION_TMP")
+          end
+
+          it "returns client" do
+            expect(Aws::SecretsManager::Client).to receive(:new).with(configuration)
+
+            client
+          end
+
+          it "sets credentials" do
+            expect(Aws::Credentials).to receive(:new).with(aws_secrets_key_value, aws_secrets_secret_value).and_return(aws_credentials_double)
+
+            client
+          end
+        end
+      end
+
+      context "with aws client supplied" do
+        let(:aws_client_double) { double() }
+
+        subject(:client) { described_class::Manager.new(client: aws_client_double).client }
+
+        it "returns aws client" do
+          expect(client).to eq(aws_client_double)
+        end
+      end
+    end
+
+    describe "#[]" do
       pending
     end
 
     describe "#fetch" do
-      pending
-    end
-
-    describe "#[]" do
       pending
     end
   end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -390,11 +390,15 @@ RSpec.describe SecretsManager do
 
           it_behaves_like("a result with processed paths")
 
-          context "sets the cache" do
+          context "when validating the cache" do
             let(:path) { "global/#{Faker::Lorem.word}" }
             let(:resolved_path) { "#{path}" }
 
-            it { expect_any_instance_of(described_class::Cache).to receive(:set).with(resolved_path, value, expires_at.to_s.to_i); fetch  }
+            it "runs the cache setting process" do
+              expect_any_instance_of(described_class::Cache).to receive(:set).with(resolved_path, value, expires_at.to_s.to_i)
+
+              fetch
+            end
           end
         end
       end

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SecretsManager do
   it "returns the correct version" do
-    expect(described_class::VERSION).to eq("1.2.0")
+    expect(described_class::VERSION).to eq("1.1.0")
   end
 
   describe "#new" do

--- a/spec/manager_spec.rb
+++ b/spec/manager_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe SecretsManager do
   it "returns the correct version" do
-    expect(described_class::VERSION).to eq("1.1.0")
+    expect(described_class::VERSION).to eq("1.2.0")
   end
 
   describe "#new" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,6 +1,7 @@
 require "bundler/setup"
 require "pry"
 require "timecop"
+require "faker"
 
 require "secrets-manager"
 
@@ -10,6 +11,10 @@ RSpec.configure do |config|
 
   # Disable RSpec exposing methods globally on `Module` and `main`
   config.disable_monkey_patching!
+
+  # Focus tests
+  config.filter_run focus: true
+  config.run_all_when_everything_filtered = true
 
   config.expect_with :rspec do |c|
     c.syntax = :expect

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,4 +1,7 @@
 require "bundler/setup"
+require "pry"
+require "timecop"
+
 require "secrets-manager"
 
 RSpec.configure do |config|
@@ -10,5 +13,13 @@ RSpec.configure do |config|
 
   config.expect_with :rspec do |c|
     c.syntax = :expect
+  end
+
+  config.before do
+    Timecop.freeze
+  end
+
+  config.after do
+    Timecop.return
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,7 +2,7 @@ require "bundler/setup"
 require "pry"
 require "timecop"
 require "faker"
-
+require "base64"
 require "secrets-manager"
 
 RSpec.configure do |config|


### PR DESCRIPTION
- add timecop for time tests in rspec
- start building test coverage on existing class functionality
- setup the specs for all of the current methods
- add gems and dependencies required to function when outside of rails
- ~bump version to 1.2.0~

The goal of this PR is provide full test coverage, and for it to be testable outside of Rails. The followup PR will add the new override method we discussed. @matt-dutchie 